### PR TITLE
refactor: move ROI widget callback funcitons to `widget.py`

### DIFF
--- a/moseq2_app/roi/controller.py
+++ b/moseq2_app/roi/controller.py
@@ -117,33 +117,8 @@ class InteractiveFindRoi(InteractiveROIWidgets):
                                                width='100%')
         self.indicator = widgets.HTML(value="")
 
-        # Set save parameters button callback
-        self.save_parameters.on_click(self.save_clicked)
-
-        # Set check all sessions button callback
-        self.check_all.on_click(self.check_all_sessions)
-
-        # Set min-max range slider callback
-        self.minmax_heights.observe(self.update_minmax_config, names='value')
-
-        # Set extract button callback
-        self.extract_button.on_click(self.extract_button_clicked)
-
-        # Set passing button callback
-        self.mark_passing.on_click(self.mark_passing_button_clicked)
-
-        # Set extract frame range slider
-        self.frame_range.observe(self.update_config_fr, names='value')
-        self.frame_num.observe(self.update_config_fn, names='value')
-
-        self.bg_roi_depth_range.observe(self.update_config_dr, names='value')
-
-        self.dilate_iters.observe(self.update_config_di, names='value')
-
         # Set session select callback
         self.checked_list.observe(self.get_selected_session, names='value')
-
-        self.clear_button.on_click(self.clear_on_click)
 
         # Update main configuration parameters
         self.minmax_heights.value = (self.config_data.get('min_height', 10), self.config_data.get('max_height', 100))

--- a/moseq2_app/roi/widgets.py
+++ b/moseq2_app/roi/widgets.py
@@ -120,6 +120,33 @@ class InteractiveROIWidgets:
                               self.message],
                              layout=self.box_layout)
 
+        ### Event Listeners ###
+
+        self.clear_button.on_click(self.clear_on_click)
+
+        # Set save parameters button callback
+        self.save_parameters.on_click(self.save_clicked)
+
+        # Set check all sessions button callback
+        self.check_all.on_click(self.check_all_sessions)
+
+        # Set min-max range slider callback
+        self.minmax_heights.observe(self.update_minmax_config, names='value')
+
+        # Set extract button callback
+        self.extract_button.on_click(self.extract_button_clicked)
+
+        # Set passing button callback
+        self.mark_passing.on_click(self.mark_passing_button_clicked)
+
+        # Set extract frame range slider
+        self.frame_range.observe(self.update_config_fr, names='value')
+        self.frame_num.observe(self.update_config_fn, names='value')
+
+        self.bg_roi_depth_range.observe(self.update_config_dr, names='value')
+
+        self.dilate_iters.observe(self.update_config_di, names='value')
+
     def clear_on_click(self, b=None):
         '''
         Clears the cell output


### PR DESCRIPTION
## Issue being fixed or feature implemented
Asynchronous widget callback functions are mixed together with unrelated functionalities in the `controller.py`.

## What was done?
- Moved all widget callback functions to `widgets.py`.
- Moved all associated EventListeners (except one) to `widgets.py`.

## How Has This Been Tested?
Tested local and in CI

## Breaking Changes
None

## Checklist:
- [ ]  I have performed a self-review of my own code
- [ ]  I have commented my code, particularly in hard-to-understand areas
- [ ]  I have added or updated relevant unit/integration/functional/e2e tests
- [ ]  I have made corresponding changes to the documentation