### PR TITLE
refactor: move Interactive Scalar widget callback functions to `widget.py`

### DIFF
--- a/moseq2_app/scalars/controller.py
+++ b/moseq2_app/scalars/controller.py
@@ -8,7 +8,6 @@ import plotly.express as px
 import plotly.graph_objects as go
 from moseq2_viz.util import parse_index
 from plotly.subplots import make_subplots
-from IPython.display import display, clear_output
 from moseq2_viz.scalars.util import scalars_to_dataframe
 from moseq2_app.scalars.widgets import InteractiveScalarWidgets
 
@@ -43,43 +42,8 @@ class InteractiveScalarViewer(InteractiveScalarWidgets):
 
         self.checked_list.options = [c for c in self.columns if c not in to_drop]
 
-        # init callback function
-        self.checked_list.observe(self.on_column_select, names='value')
-        self.clear_button.on_click(self.on_clear)
-
         # set default values
         self.checked_list.value = ['velocity_2d_mm', 'velocity_3d_mm', 'height_ave_mm', 'width_mm', 'length_mm']
-
-    def on_clear(self, b=None):
-        '''
-        Clears the display and memory.
-
-        Parameters
-        ----------
-        b (button Event): Ipywidgets.Button click event.
-
-        Returns
-        -------
-        '''
-
-        clear_output()
-        del self
-
-    def on_column_select(self, event=None):
-        '''
-        Updates the view once the user selects a new set of scalars to plot.
-
-        Parameters
-        ----------
-        event
-
-        Returns
-        -------
-        '''
-
-        clear_output()
-        display(self.ui_tools)
-        self.interactive_view()
 
     def make_graphs(self):
         '''

--- a/moseq2_app/scalars/widgets.py
+++ b/moseq2_app/scalars/widgets.py
@@ -3,8 +3,9 @@
 Ipywidgets used to facilitate interactive scalar summary viewer tool.
 
 '''
-import ipywidgets as widgets
 from ipywidgets import VBox
+import ipywidgets as widgets
+from IPython.display import display, clear_output
 
 class InteractiveScalarWidgets:
     '''
@@ -34,3 +35,38 @@ class InteractiveScalarWidgets:
                                                    continuous_update=False, disabled=False, layout=self.label_layout)
 
         self.ui_tools = VBox([self.clear_button, self.checked_list], layout=self.box_layout)
+
+        # initialize event listeners
+        self.checked_list.observe(self.on_column_select, names='value')
+        self.clear_button.on_click(self.on_clear)
+
+    def on_clear(self, b=None):
+        '''
+        Clears the display and memory.
+
+        Parameters
+        ----------
+        b (button Event): Ipywidgets.Button click event.
+
+        Returns
+        -------
+        '''
+
+        clear_output()
+        del self
+
+    def on_column_select(self, event=None):
+        '''
+        Updates the view once the user selects a new set of scalars to plot.
+
+        Parameters
+        ----------
+        event
+
+        Returns
+        -------
+        '''
+
+        clear_output()
+        display(self.ui_tools)
+        self.interactive_view()


### PR DESCRIPTION
## Issue being fixed or feature implemented
- Asynchronous widget callback functions are mixed together with unrelated functionalities in the `scalars/controller.py`.

## What was done?
- Moved all widget callback functions from `scalars/controller.py` to `scalars/widgets.py`.
- Moved all associated EventListeners to `scalars/widgets.py`.

## How Has This Been Tested?
Tested local and in CI

## Breaking Changes
None

## Checklist:
- [ ]  I have performed a self-review of my own code
- [ ]  I have commented my code, particularly in hard-to-understand areas
- [ ]  I have added or updated relevant unit/integration/functional/e2e tests
- [ ]  I have made corresponding changes to the documentation