### PR TITLE
fix: Save setting button in syllable labeler not correctly saving and unnecessary var in on_next method

### DIFF
--- a/moseq2_app/viz/widgets.py
+++ b/moseq2_app/viz/widgets.py
@@ -168,7 +168,7 @@ class SyllableLabelerWidgets:
         self.syll_info[self.syll_select.index]['label'] = self.lbl_name_input.value
         self.syll_info[self.syll_select.index]['desc'] = self.desc_input.value
 
-        self.write_syll_info()
+        self.write_syll_info(curr_syll=self.syll_select.index)
 
         # Update button style
         self.set_button.button_style = 'success'


### PR DESCRIPTION
## Issue being fixed or feature implemented
Save Setting button not correctly saving the syllable name in `SyllableLabelerWidgets` and unnecessary var `curr_index` in `on_next` method.
## How Has This Been Tested?
Tested in Travis CI and locally on Jupyter Notebook
## Breaking Changes
No breaking changes
## Checklists
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ]  I have added or updated relevant unit/integration/functional/e2e tests
- [ ]  I have made corresponding changes to the documentation