### PR TITLE
fix: crowd movie comparison key error from reading a bigger data frame

### DIFF
--- a/moseq2_app/viz/controller.py
+++ b/moseq2_app/viz/controller.py
@@ -534,6 +534,7 @@ class CrowdMovieComparison(CrowdMovieCompareWidgets):
         for gd in group_dicts:
             group_name = list(gd.keys())[0]
             for syll in list(gd[group_name]['syllable'].keys()):
+                # ensure syll is less than max number of syllables
                 if syll < self.max_sylls:
                     try:
                         self.group_syll_info[syll]['group_info'][group_name] = {


### PR DESCRIPTION
## Issue being fixed or feature implemented
`max_syll` represents the maximum number of syllables needed to account for certain threshold hold of explained variance. Since not all the syllables computed from `compute_behavioral_statistics` are included in the maximum number of syllables needed, the widget will falsely raise warnings saying a variable is not in a group. Fixed the bug by adding `max_syll` as the threshold.
## How Has This Been Tested?
Tested in Travis CI and locally on Jupyter Notebook
## Breaking Changes
No breaking changes
## Checklists
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ]  I have added or updated relevant unit/integration/functional/e2e tests
- [ ]  I have made corresponding changes to the documentation