### PR TITLE
fix(test): added context manager to `test_check_timestamp_error_percentage()`

### DIFF
--- a/tests/gui_tests/test_validation.py
+++ b/tests/gui_tests/test_validation.py
@@ -20,7 +20,9 @@ class TestExtractionValidation(TestCase):
         }
 
         h5path = paths['session_1'].replace('mp4', 'h5')
-        timestamps = h5py.File(h5path, 'r')['timestamps'][()]
+
+        with h5py.File(h5path, 'r') as f:
+            timestamps = f['timestamps'][()]
 
         percent_error = check_timestamp_error_percentage(timestamps)
 


### PR DESCRIPTION
## Issue being fixed or feature implemented
`test_check_timestamp_error_percentage` was opening h5py file without using a context manager.

## How Has This Been Tested?
Locally and Travis

## What Was Done?
Replaced vanilla h5 file open with context manager.

## Breaking Changes
None

## Checklists
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation
