### PR TITLE
fix: moseq installation not pointing to the correct position and branch

### DIFF
--- a/scripts/install_moseq2_app.sh
+++ b/scripts/install_moseq2_app.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-pip install -e .
+pip install .
 
 # Install and Enable widget extensions configurator
 jupyter nbextension install --py jupyter_nbextensions_configurator --sys-prefix

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ setup(
                       'moseq2-extract @ git+https://github.com/dattalab/moseq2-extract.git@dev',
                       'moseq2-pca @ git+https://github.com/dattalab/moseq2-pca.git@release',
                       'moseq2-model @ git+https://github.com/dattalab/moseq2-model.git@release',
-                      'moseq2-viz @ git+https://github.com/dattalab/moseq2-viz.git@release-update'
+                      'moseq2-viz @ git+https://github.com/dattalab/moseq2-viz.git@dev'
                       ],
     python_requires='>=3.6,<3.8'
 )


### PR DESCRIPTION
## Issue being fixed or feature implemented
MoSeq installation points to the directory that users can interact with. If the users accidentally change anything in the folder, MoSeq might not work as expected. `moseq2-viz` is not on `dev` branch, so `setup.py` doesn't install the most updated version.

## How Has This Been Tested?
Locally and Travis

## What Was Done?
Changed the pip install command such that the installation will be in site-packages.

Changed the branch for `moseq2-viz`.

## Breaking Changes
None

## Checklists
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
