### PR TITLE
chore: clean up `Flip Classifier Training Notebook.ipynb`

### DIFF
--- a/notebooks/Flip Classifier Training Notebook.ipynb
+++ b/notebooks/Flip Classifier Training Notebook.ipynb
@@ -30,9 +30,9 @@
     "\n",
     "### Instructions\n",
     "1. Specify the the path to the input data folder in `input_dir`, and the path to the resulting flip classifier model.\n",
-    "2. Specify the maximum number of frames to use** in the `max_frames` field, the default value is 1e5.\n",
-    "3. Specify the number of tail filter iterations** in the `tail_filter_iters` field, the default value is 1.\n",
-    "4. Specify the size of the spatial median blur filter kernel size** in the `space_filter_size` field, the default value is 3.\n",
+    "2. Specify the maximum number of frames to use in the `max_frames` field, the default value is 1e5.\n",
+    "3. Specify the number of tail filter iterations in the `tail_filter_iters` field, the default value is 1.\n",
+    "4. Specify the size of the spatial median blur filter kernel size in the `space_filter_size` field, the default value is 3.\n",
     "5. Select a sesseion from the dropdown menu.\n",
     "6. Drag the slider to select a frame index to preview, or enter the frame number in the indicator located on the right side of the frame slider.\n",
     "7. Click `Start Range` to starting selecting the range. Drag the slider to the end of the range. Click `Facing Left` (when the rodent's head is facing left) or `Facing Right` (when the rodent's head is facing right) to specify the correct orientation for the range of frames. After specifying the orientation, the selected frames will be added to the dataset used to train the model. **The list on the right side will indicate the specified direction, session name, and selected frame range that are added to the training set.** . \n",
@@ -218,7 +218,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.7"
+   "version": "3.7.10"
   },
   "pycharm": {
    "stem_cell": {


### PR DESCRIPTION
## Issue being fixed or feature implemented
The documentation and inline comments in `Flip Classifier Training Notebook.ipynb` need cleaning up.

## How Has This Been Tested?
Locally and Travis

## What Was Done?
- Deleted blurry images
- Deleted unnecessary inline comments
- Added instructions and rewrote documentation.

## Breaking Changes
None

## Checklists
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
