### PR TITLE
fix: significant syllable diamonds were not reordered to match the plot

### DIFF
--- a/moseq2_app/stat/controller.py
+++ b/moseq2_app/stat/controller.py
@@ -311,7 +311,7 @@ class InteractiveSyllableStats(SyllableStatWidgets):
                 sig_sylls_indices = self.run_selected_hypothesis_test(hyp_test, stat, ctrl_group, exp_group)
 
                 # renumber the significant syllables s.t. they are plotted to match the current ordering.
-                ordermapping = {i: o for i, o in enumerate(ordering)}
+                ordermapping = {o: i for i, o in enumerate(ordering)}
                 sig_sylls = [ordermapping[x] for x in sig_sylls_indices]
 
         elif sort.lower() == 'similarity':


### PR DESCRIPTION
## Issue being fixed or feature implemented
Significant Syllables were not being renumbered to reflect the syllable ordering being displayed.

## How Has This Been Tested?
Locally and Travis

## What Was Done?
- Created a dict `ordermapping` that is used to renumber the outputted significant syllables based on the `ordering` variable and the sequential order that the syllables are plotted.
    -  E.g. if  `ordering = [5,4,3,2,1,0]` and `sig_syll_indices = [2,5]`. Then `sig_sylls = [3,0]`, meaning that the diamonds will be plotted on the third and zeroth **index** of the x-axis paired with the syllable that was originally marked as significant.

## Breaking Changes
None

## Checklists
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation
