### PR TITLE
fix: Node color label "Duration" does not match updated thresholding label

### DIFF
--- a/moseq2_app/stat/widgets.py
+++ b/moseq2_app/stat/widgets.py
@@ -340,7 +340,7 @@ class TransitionGraphWidgets:
             self.speed_thresholder.description = 'Threshold Nodes by 2D Velocity'
         elif event.new == 'Duration':
             key = 'duration'
-            self.speed_thresholder.description = 'Threshold Nodes by 2D Velocity'
+            self.speed_thresholder.description = 'Threshold Nodes by Duration'
         elif event.new == '2D velocity':
             key = 'velocity_2d_mm'
             self.speed_thresholder.description = 'Threshold Nodes by 2D Velocity'


### PR DESCRIPTION
## Issue being fixed or feature implemented
- Node thresholding slider is not updated correctly when the node coloring is by Duration.
- Error mentioned in Issue: #122

## How Has This Been Tested?
Locally and Travis

## What Was Done?
Updated incorrect widget label mapping in `on_set_scalar()` for 'duration`.
- Thresholding slider will revert back to thresholding by 2D velocity if the node coloring is done by entropy-in/out or "default".

## Breaking Changes
None

## Checklists
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
