### PR TITLE
fix: removing similarity sorting option due to unstable behavior for individual session stat plotting

### DIFF
--- a/moseq2_app/stat/widgets.py
+++ b/moseq2_app/stat/widgets.py
@@ -22,7 +22,7 @@ class SyllableStatWidgets:
 
         self.stat_dropdown = widgets.Dropdown(options=['usage', 'duration', '2D Velocity', '3D Velocity', 'Height', 'Distance to Center'], description='Stat to Plot:', disabled=False)
 
-        self.sorting_dropdown = widgets.Dropdown(options=['usage', 'duration', '2D Velocity', '3D Velocity', 'Height', 'Distance to Center', 'Similarity', 'Difference'], description='Sorting:', disabled=False)
+        self.sorting_dropdown = widgets.Dropdown(options=['usage', 'duration', '2D Velocity', '3D Velocity', 'Height', 'Distance to Center', 'Difference'], description='Sorting:', disabled=False)
         self.thresholding_dropdown = widgets.Dropdown(
             options=['usage', 'duration', '2D Velocity', '3D Velocity', 'Height', 'Distance to Center'],
             description='Threshold By:', disabled=False, style=style)


### PR DESCRIPTION
## Issue being fixed or feature implemented
- Issue mentioned in #121 
- Similarity sorting + individual session plotting raises TypeError.

## How Has This Been Tested?
Locally and Travis

## What Was Done?
- Removed option to sort by similarity from the widget options.

## Breaking Changes
None

## Checklists
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
