### PR TITLE
fix: replaced dict-mapping with np.argsort

### DIFF
--- a/moseq2_app/stat/controller.py
+++ b/moseq2_app/stat/controller.py
@@ -311,7 +311,7 @@ class InteractiveSyllableStats(SyllableStatWidgets):
                 sig_sylls_indices = self.run_selected_hypothesis_test(hyp_test, stat, ctrl_group, exp_group)
 
                 # renumber the significant syllables s.t. they are plotted to match the current ordering.
-                sig_sylls = sig_sylls = np.argsort(ordering)[sig_sylls_indices]
+                sig_sylls = np.argsort(ordering)[sig_sylls_indices]
 
         elif sort.lower() == 'similarity':
             ordering = self.results['leaves']


### PR DESCRIPTION
## Issue being fixed or feature implemented
- Fixing implementation for syllable reordering.

## How Has This Been Tested?
Locally and Travis

## What Was Done?
- Replacing `ordermapping` dict with `np.argsort`

## Breaking Changes
None

## Checklists
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
