### PR TITLE
chore: delete gcc and gxx in moseq-env.yaml

### DIFF
--- a/scripts/moseq2-env.yaml
+++ b/scripts/moseq2-env.yaml
@@ -11,6 +11,7 @@ dependencies:
   - conda-forge::opencv
   - jupyter_nbextensions_configurator
   - scikit-image=0.16.2
+  - fastparquet=0.4.1
   - pip:
       - numpy==1.18.3
       - pandas==1.0.5


### PR DESCRIPTION
## Issue being fixed or feature implemented
Previously there are two separate conda environment yaml files for MacOS and Linux to handle the gcc and gxx dependencies. It is more generalizable and simpler to require users to manually check and install gcc-7 and g++-7, and provide one conda environment yaml file instead.


## What was done?
`gcc_linux-64=9.3.0` and `gxx_linux-64=9.3.0` are deleted from the moseq-env.yaml


## How Has This Been Tested?
Tested locally and CI


## Breaking Changes
The conda environment yaml file doesn't include gcc and g++, all users will need to manually install them.


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
