### PR TITLE
fix: Pytest Test Suite runs into an infinite loop after large amount of unreaped video writing processes on MacOS

### DIFF
--- a/tests/gui_tests/test_main.py
+++ b/tests/gui_tests/test_main.py
@@ -1,6 +1,7 @@
 import os
 import shutil
 import ruamel.yaml as yaml
+import multiprocessing as mp
 from unittest import TestCase
 from os.path import exists, join
 from moseq2_viz.util import parse_index
@@ -10,6 +11,9 @@ from moseq2_app.main import (interactive_roi_detector, preview_extractions, vali
                              interactive_group_setting, label_syllables, interactive_syllable_stats,
                              interactive_crowd_movie_comparison, interactive_transition_graph,
                              view_extraction, flip_classifier_tool)
+
+# Source: https://bugs.python.org/issue33725#msg329923
+mp.set_start_method('forkserver')
 
 class TestMain(TestCase):
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- #137
- On MacOS, pytest runs into an infinite loop after running many video writing commands within the same test class.
Running `pytest -s -v` reveals a warning message that is raised when each new crowd movie writing function is called:
```
UserWarning: semaphore_tracker: There appear to be 1 leaked semaphores to clean up at shutdown.
```
This warning is an indicator that the repetitive calls to video writing functions within a single test class will lead to an infinite loop.

## What was done?
- Changed the `multiprocessing` context at the start of `test_main.py` as per [this forum comment](https://bugs.python.org/issue33725#msg329923).
- According to the [multiprocessing docs](https://docs.python.org/3/library/multiprocessing.html#contexts-and-start-methods), using `'forkserver'` as the starting method is a safer alternative because the forked processes are single-threaded. Additionally, no unnecessary resources are inherited.


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Locally and Travis

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
