### PR TITLE
Fix: check progress uses the wrong path for changepoints

### DIFF
--- a/moseq2_app/gui/progress.py
+++ b/moseq2_app/gui/progress.py
@@ -448,7 +448,7 @@ def get_pca_progress(progress_vars, pca_progress):
                     pca_progress[key] = True
             # changepoints field only include the filename with no path and extension
             elif key == 'changepoints_path':
-                # mannually construct the path for changepoints.h5
+                # manually construct the path for changepoints.h5
                 if exists(join(progress_vars['pca_dirname'], progress_vars[key] + '.h5')):
                     pca_progress[key] = True
             else:


### PR DESCRIPTION
## Issue being fixed or feature implemented
`moseq2_app.gui.progress` `check_progress` will always show 3/4 for PCA Progress because the changepoints.h5 path incorrectly checked.

https://github.com/dattalab/moseq2-app/issues/142

## What was done?
In `get_pca_progress` I constructed the full path for `changepoints.h5`.


## How Has This Been Tested?
CI and locally.


## Breaking Changes
NA


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
