### PR TITLE
fix: Outputted ROI was not being updated when depth range sliders were manually updated

### DIFF
--- a/moseq2_app/roi/widgets.py
+++ b/moseq2_app/roi/widgets.py
@@ -325,7 +325,8 @@ class InteractiveROIWidgets:
         -------
         '''
 
-        self.config_data['detect'] = False
+        # setting detect to true in order to update the displayed ROI based on the current DR values
+        self.config_data['detect'] = True
 
         self.config_data['bg_roi_depth_range'] = (int(self.bg_roi_depth_range.value[0]), int(self.bg_roi_depth_range.value[1]))
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
When users manually adjust the depth range after it is automatically set, the outputted ROI is unchanged. The expected behavior is that the newly computed ROI is updated based on the manually set widget slider values.

## What was done?
<!--- Describe your changes in detail -->
In the function `roi.widgets.update_config_dr()`, the `config_data['detect']` parameter is now set to `True` in order to appropriately update the outputted ROI according to the user's manually set depth range values.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Locally and Travis

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
