### PR TITLE
chore: Assign group widget clarity

### DIFF
--- a/moseq2_app/gui/widgets.py
+++ b/moseq2_app/gui/widgets.py
@@ -42,7 +42,7 @@ class GroupSettingWidgets:
         self.clear_button = widgets.Button(description='Clear Output', disabled=False, tooltip='Close Cell Output')
 
         self.group_input = widgets.Text(value='', placeholder='Enter Group Name to Set', style=style,
-                                        description='Assign Group Name to', continuous_update=False, disabled=False)
+                                        description='New Group Name', continuous_update=False, disabled=False)
         self.save_button = widgets.Button(description='Set Group Name', style=style,
                                           disabled=False, tooltip='Set Group')
         self.update_index_button = widgets.Button(description='Update Index File', style=style,


### PR DESCRIPTION
## Issue being fixed or feature implemented
The widget description in the assign group is confusing so this PR should improve the clarity per my discussion with @wingillis 

## What was done?
The widget now looks like this 
![image](https://user-images.githubusercontent.com/17051660/133491836-db132066-bf6a-497b-acca-dd1f9f0f8254.png)



## How Has This Been Tested?
NA

## Breaking Changes
NA

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
