### PR TITLE
test: Added Ubuntu 20.04 (Focal Fossa) Installation Test Case

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,8 @@ python: '3.6'
 dist: xenial
 
 stages:
-  - conda-script
   - pip-install
+  - conda-script
   - name: latest-pythons
     if: branch = release
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->
Ubuntu 20.04 cannot add the same ppa repositories as 16/18.04, so `apt install build-essentials` is used to install `g++-7`.

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- Missing test builds for multiple Ubuntu versions; now running Xenial and Focal build stages.
 Related issue: https://github.com/dattalab/moseq2-app/issues/179

## What was done?
<!--- Describe your changes in detail -->
- Added new test case for Ubuntu 20.04 with Xenial-based commands are replaced with `apt install build-essentials`.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Locally - Docker and Travis

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
