### PR TITLE
feat: download script to download extracted data and model results

### DIFF
--- a/scripts/download_extracted_model_results.sh
+++ b/scripts/download_extracted_model_results.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+mkdir test_data
+cd test_data
+
+
+# Config file
+curl -L -o config.yaml https://www.dropbox.com/s/5nb3rih0kr9d20b/config_modeled.yaml?dl=0
+
+# Progress File
+curl -L -o progress.yaml https://www.dropbox.com/s/pu77qvk77uvn7s4/progress_modeled.yaml?dl=0
+
+# Index File
+curl -L -o moseq2-index.yaml  https://www.dropbox.com/s/hantgvvai1r0xbo/moseq2-index_modeled.yaml?dl=0
+
+# Aggregate Sessions
+curl -L -o aggregate_results.zip https://www.dropbox.com/sh/bfr1o39l7iasgnw/AADRzo-aWAZAHQQP1yzELX1Sa?dl=1 && unzip aggregate_results.zip -d aggregate_results
+rm aggregate_results.zip
+
+# PCA Files
+curl -L -o _pca.zip https://www.dropbox.com/sh/fhhietihmxud9tb/AACYUbCiZmtxkqb-QDoymfnCa?dl=0 && unzip _pca.zip -d _pca
+rm _pca.zip
+
+# Modeling Files
+curl -L -o saline-amphetamine.zip https://www.dropbox.com/sh/dpaiacewonlh7nb/AABlal7f2TCyBtMTUbjhHoBDa?dl=0  && unzip saline-amphetamine.zip -d saline-amphetamine
+rm saline-amphetamine.zip
+


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
I added a script to download the folder of aggregate results and the modeling results so users can download the dataset to play around with the analysis&viz notebook.


## What was done?
I added a download script and changed the config.yaml, moseq2-index.yaml and progress.yaml to achieve the goal.


## How Has This Been Tested?
locally


## Breaking Changes
NA


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation
