### PR TITLE
chore: remove spectral layout for transition matrix visualization

### DIFF
--- a/moseq2_app/stat/widgets.py
+++ b/moseq2_app/stat/widgets.py
@@ -258,7 +258,7 @@ class TransitionGraphWidgets:
         ui_layout = widgets.Layout(flex_flow='row', border='solid', align_items='stretch',
                                    width='100%', justify_content='space-around')
 
-        self.graph_layout_dropdown = widgets.Dropdown(options=['circular',  'spring', 'spectral'],
+        self.graph_layout_dropdown = widgets.Dropdown(options=['circular',  'spring'],
                                                       description='Graph Layout',
                                                       style=style, value='circular', continuous_update=False,
                                                       layout=widgets.Layout(align_items='stretch', width='80%'))


### PR DESCRIPTION
## Issue being fixed or feature implemented
remove spectral layout for transition matrix visualization


## What was done?
Deleted spectral layout from the list


## How Has This Been Tested?
CI and locally

## Breaking Changes


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
