### PR TITLE
feat: adding param to select instances close to duration median

### DIFF
--- a/moseq2_app/gui/wrappers.py
+++ b/moseq2_app/gui/wrappers.py
@@ -49,7 +49,7 @@ def validate_extractions_wrapper(input_dir):
     print_validation_results(scalar_df, status_dicts)
 
 def interactive_syllable_labeler_wrapper(model_path, config_file, index_file, crowd_movie_dir, output_file,
-                                         max_syllables=None, n_explained=99, duration_opt=False):
+                                         max_syllables=None, n_explained=99, select_median_duration_instances=False):
     '''
     Wrapper function to launch a syllable crowd movie preview and interactive labeling application.
 
@@ -88,7 +88,7 @@ def interactive_syllable_labeler_wrapper(model_path, config_file, index_file, cr
                               index_file=index_file,
                               config_file=config_file,
                               max_sylls=max_sylls,
-                              duration_opt=duration_opt,
+                              select_median_duration_instances=select_median_duration_instances,
                               crowd_movie_dir=crowd_movie_dir,
                               save_path=output_file)
 

--- a/moseq2_app/main.py
+++ b/moseq2_app/main.py
@@ -208,7 +208,7 @@ def interactive_scalar_summary(index_file):
     return viewer
 
 @filter_warnings
-def label_syllables(progress_paths, max_syllables=None, n_explained=99, duration_opt=False):
+def label_syllables(progress_paths, max_syllables=None, n_explained=99, select_median_duration_instances=False):
     '''
     Interactive syllable labeling tool accessible from the jupyter notebook.
 
@@ -237,7 +237,7 @@ def label_syllables(progress_paths, max_syllables=None, n_explained=99, duration
 
     interactive_syllable_labeler_wrapper(model_path, config_file,
                                          index_file, crowd_dir, syll_info_path,
-                                         max_syllables=max_syllables, n_explained=n_explained, duration_opt=duration_opt)
+                                         max_syllables=max_syllables, n_explained=n_explained, select_median_duration_instances=select_median_duration_instances)
 
 @filter_warnings
 def interactive_syllable_stats(progress_paths, max_syllable=None, load_parquet=False):

--- a/moseq2_app/viz/controller.py
+++ b/moseq2_app/viz/controller.py
@@ -43,7 +43,7 @@ class SyllableLabeler(SyllableLabelerWidgets):
 
     '''
 
-    def __init__(self, model_fit, model_path, index_file, config_file, max_sylls, duration_opt, crowd_movie_dir, save_path):
+    def __init__(self, model_fit, model_path, index_file, config_file, max_sylls, select_median_duration_instances, crowd_movie_dir, save_path):
         '''
         Initializes class context parameters, reads and creates the syllable information dict.
 
@@ -52,7 +52,7 @@ class SyllableLabeler(SyllableLabelerWidgets):
         model_fit (dict): Loaded trained model dict.
         index_file (str): Path to saved index file.
         max_sylls (int): Maximum number of syllables to preview and label.
-        duration_opt (bool): if true, select examples with syallable duration closer to median.
+        select_median_duration_instances (bool): if true, select examples with syallable duration closer to median.
         save_path (str): Path to save syllable label information dictionary.
         '''
 
@@ -63,7 +63,7 @@ class SyllableLabeler(SyllableLabelerWidgets):
         # by passing max_syllables=None to the wrapper/main.py function::label_syllables. Otherwise, if a integer
         # is inputted, then self.max_sylls is set to that same integer.
         self.max_sylls = max_sylls
-        self.duration_opt = duration_opt
+        self.select_median_duration_instances = select_median_duration_instances
 
         self.config_data = read_yaml(config_file)
 
@@ -347,7 +347,7 @@ class SyllableLabeler(SyllableLabelerWidgets):
         config_data['separate_by'] = ''
         config_data['specific_syllable'] = None
         config_data['max_syllable'] = self.max_sylls
-        config_data['duration_opt'] = self.duration_opt
+        config_data['select_median_duration_instances'] = self.select_median_duration_instances
         config_data['max_examples'] = 20
         config_data['gaussfilter_space'] = [0, 0]
         config_data['medfilter_space'] = [0]

--- a/notebooks/MoSeq2-Analysis-Visualization-Notebook.ipynb
+++ b/notebooks/MoSeq2-Analysis-Visualization-Notebook.ipynb
@@ -376,14 +376,15 @@
     "# To instead label a fixed number of syllables, set max_syllables <= nstates\n",
     "max_syllables = None\n",
     "\n",
-    "# To generate crowd movies selecting syllable instances that are close to syllable duration median, set select_median_duration_instances =True\n",
+    "# To generate crowd movies selecting syllable instances that are close to syllable duration median\n",
+    "# set select_median_duration_instances = True and delete the existing crowd_movie folder\n",
     "select_median_duration_instances = False\n",
     "\n",
     "update_progress(progress_filepath, 'crowd_dir', crowd_dir)\n",
     "update_progress(progress_filepath, 'syll_info', syll_infopath)\n",
     "progress_paths = update_progress(progress_filepath, 'df_info_path', syll_info_df_path)\n",
     "\n",
-    "label_syllables(progress_paths, max_syllables=max_syllables, n_explained=explained_variance, duration_opt=select_median_duration_instances)"
+    "label_syllables(progress_paths, max_syllables=max_syllables, n_explained=explained_variance, select_median_duration_instances=select_median_duration_instances)"
    ]
   },
   {


### PR DESCRIPTION
## Issue being fixed or feature implemented
adding duration_opt to select instances close to duration median
related: https://github.com/dattalab/moseq2-viz/pull/149


## What was done?
changed the notebook and the related functions


## How Has This Been Tested?
locally and CI


## Breaking Changes
Now functions take additional duration_opt as param.


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation
