### PR TITLE
feat: add option to exclude errorbar and picking colors better

### DIFF
--- a/moseq2_app/stat/controller.py
+++ b/moseq2_app/stat/controller.py
@@ -289,7 +289,7 @@ class InteractiveSyllableStats(SyllableStatWidgets):
         sort (str or ipywidgets.DropDown): Statistic to sort syllables by (in descending order).
             ['usage', 'distance to center', 'similarity', 'difference'].
         groupby (str or ipywidgets.DropDown): Data to plot; either group averages, or individual session data.
-        errorbar (str or ipywidgets.DropDown): Error bar to display. ['CI 95%' ,'SEM', 'STD']
+        errorbar (str or ipywidgets.DropDown): Error bar to display. ['None', 'CI 95%' ,'SEM', 'STD']
         sessions (list or ipywidgets.MultiSelect): List of selected sessions to display data from.
         ctrl_group (str or ipywidgets.DropDown): Name of control group to compute group difference sorting with.
         exp_group (str or ipywidgets.DropDown): Name of comparative group to compute group difference sorting with.
@@ -340,7 +340,11 @@ class InteractiveSyllableStats(SyllableStatWidgets):
         if groupby == 'SessionName' or groupby == 'SubjectName':
             mean_df = df.copy()
             df = df[df[groupby].isin(self.session_sel.value)]
+            # set error bar to None because error bars are not implemented corectly in SessionName and SubjectName
+            errorbar = "None"
+            self.error_box.layout.display = "none"
         else:
+            self.error_box.layout.display = "block"
             mean_df = None
 
         # Compute cladogram if it does not already exist

--- a/moseq2_app/stat/view.py
+++ b/moseq2_app/stat/view.py
@@ -299,7 +299,7 @@ def get_aux_stat_dfs(df, group, sorting, groupby='group', errorbar='CI 95%', sta
     errs_x (list): list of x-indices to plot the error bar lines within.
     errs_y (list): list of y-indices to plot the error bar lines within.
     '''
-
+    
     # Get group specific dataframe indices
     df_group = df[df[groupby] == group]
     grouped = df_group.groupby('syllable')[[stat]]
@@ -324,6 +324,10 @@ def get_aux_stat_dfs(df, group, sorting, groupby='group', errorbar='CI 95%', sta
     if errorbar == 'CI 95%':
         miny = [e[0] for e in stat_err]
         maxy = [e[1] for e in stat_err]
+    # miny, maxy is just y. Sorry, I have to do this to match the rest of the code
+    elif errorbar == 'None':
+        miny = aux_df[stat]
+        maxy = aux_df[stat]
     else:
         miny = aux_df[stat] - stat_err[stat]
         maxy = aux_df[stat] + stat_err[stat]

--- a/moseq2_app/stat/widgets.py
+++ b/moseq2_app/stat/widgets.py
@@ -34,7 +34,7 @@ class SyllableStatWidgets:
         self.session_sel = widgets.SelectMultiple(options=[], description='Sessions:', rows=10,
                                                   layout=self.layout_hidden, disabled=False)
 
-        self.errorbar_dropdown = widgets.Dropdown(options=['CI 95%', 'SEM', 'STD'], description='Error Bars:', disabled=False)
+        self.errorbar_dropdown = widgets.Dropdown(options=['None', 'CI 95%', 'SEM', 'STD'], description='Error Bars:', disabled=False)
 
         self.hyp_test_dropdown = widgets.Dropdown(options=['KW & Dunn\'s', 'Z-Test', 'T-Test', 'Mann-Whitney'], description='Hypothesis Test:',
                                                   style=style, disabled=False)
@@ -42,13 +42,14 @@ class SyllableStatWidgets:
         ## boxes
         self.data_layout = widgets.Layout(flex_flow='row', padding='top', justify_content='space-around', width='100%')
 
-        self.stat_box = VBox([self.stat_dropdown, self.errorbar_dropdown])
+        self.stat_box = VBox([self.stat_dropdown])
+        self.error_box = VBox([self.errorbar_dropdown])
         self.mutation_box = VBox([self.ctrl_dropdown, self.exp_dropdown, self.hyp_test_dropdown])
 
         self.sorting_box = VBox([self.sorting_dropdown, self.mutation_box, self.thresholding_dropdown])
         self.session_box = VBox([self.grouping_dropdown, self.session_sel])
 
-        self.stat_widget_box = VBox([HBox([self.stat_box, self.sorting_box, self.session_box])])
+        self.stat_widget_box = VBox([HBox([VBox([self.stat_box, self.error_box]), self.sorting_box, self.session_box])])
     
     def clear_on_click(self, b=None):
         '''
@@ -90,7 +91,6 @@ class SyllableStatWidgets:
             self.session_sel.layout.display = "none"
 
         self.session_sel.value = [self.session_sel.options[0]]
-
 class SyllableStatBokehCallbacks:
     def __init__(self, condition=''):
         '''


### PR DESCRIPTION
## Issue being fixed or feature implemented
Previously there is no option to not plot the error bar and the colors are not set optimally

## What was done?
<!--- Describe your changes in detail -->
add option to exclude error bar
![image](https://user-images.githubusercontent.com/17051660/151252760-af3be6bd-ed1a-460f-b7b3-2b104b249183.png)
additionally when grouping is session name or subject name, error bar option is not available because it is not implemented correctly.
![image](https://user-images.githubusercontent.com/17051660/151253043-c950c525-f7c7-4ab9-a18a-4fcb6dfbcd19.png)
Also removed the confusing color picker and better set colors more optimally.


## How Has This Been Tested?
CI and locally


## Breaking Changes
Now more color picker.


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation
