### PR TITLE
chore: simplify updating model paths

### DIFF
--- a/moseq2_app/util.py
+++ b/moseq2_app/util.py
@@ -188,10 +188,10 @@ def update_model_paths(desired_model, model_dict, progress_filepath):
     for key in ['model_session_path', 'model_path']:
         progress_paths = update_progress(progress_filepath, key, model_dict[desired_model].get(key))
     progress_paths = update_progress(progress_filepath, 'plot_path', join(model_dict[desired_model]['model_session_path'], 'plots/'))
+    progress_paths = update_progress(progress_filepath, 'crowd_dir', join(model_dict[desired_model]['model_session_path'], 'crowd_movies/'))
+    progress_paths = update_progress(progress_filepath, 'syll_info', join(model_dict[desired_model]['model_session_path'], 'syll_info.yaml'))
+    progress_paths = update_progress(progress_filepath, 'df_info_path', join(model_dict[desired_model]['model_session_path'], 'syll_df.parquet'))
 
-    # reset paths in progress_paths
-    for key in ['crowd_dir', 'syll_info', 'df_info_path']:
-        progress_paths = update_progress(progress_filepath, key, '')
     return progress_paths
 
 


### PR DESCRIPTION
## Issue being fixed or feature implemented
updating model path wipes the paths to syll_info and crowd movies. that's a legacy from not saving model-specific results to model specific folders.


## What was done?
update the syll_info, crowd movie and parquet path.


## How Has This Been Tested?
locally


## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
