### PR TITLE
chore: remove save parquet

### DIFF
--- a/moseq2_app/viz/controller.py
+++ b/moseq2_app/viz/controller.py
@@ -200,9 +200,9 @@ class SyllableLabeler(SyllableLabelerWidgets):
             # sorted/relabeled syllable usage and duration information from [0, max_syllable) inclusive
             df, scalar_df = merge_labels_with_scalars(self.sorted_index, self.model_path)
             df = df.astype(dict(SubjectName=str, SessionName=str))
-            print('Writing main syllable info to parquet')
-            df.to_parquet(self.df_output_file, engine='fastparquet', compression='gzip')
-            scalar_df.to_parquet(self.scalar_df_output, compression='gzip')
+            # print('Writing main syllable info to parquet')
+            # df.to_parquet(self.df_output_file, engine='fastparquet', compression='gzip')
+            # scalar_df.to_parquet(self.scalar_df_output, compression='gzip')
         else:
             print('Loading parquet files')
             df = pd.read_parquet(self.df_output_file, engine='fastparquet')


### PR DESCRIPTION
## Issue being fixed or feature implemented
turn off the save parquet function


## What was done?
commented out the save parquet part for the dataframe since users won't know how to access the files and we already save the df as csv.


## How Has This Been Tested?
locally


## Breaking Changes
no more parquet files 


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
